### PR TITLE
Fix annealing bug

### DIFF
--- a/swarm_rl/env_wrappers/reward_shaping.py
+++ b/swarm_rl/env_wrappers/reward_shaping.py
@@ -18,10 +18,10 @@ DEFAULT_QUAD_REWARD_SHAPING['quad_rewards'].update(dict(
 ))
 
 
-class QuadsRewardShapingWrapper(gym.Wrapper, RewardShapingInterface, TrainingInfoInterface):
+class QuadsRewardShapingWrapper(gym.Wrapper, TrainingInfoInterface):
     def __init__(self, env, reward_shaping_scheme=None, annealing=None):
         gym.Wrapper.__init__(self, env)
-        RewardShapingInterface.__init__(self)
+        # RewardShapingInterface.__init__(self)
         TrainingInfoInterface.__init__(self)
 
         self.reward_shaping_scheme = reward_shaping_scheme

--- a/swarm_rl/runs/quad_multi_mix_baseline.py
+++ b/swarm_rl/runs/quad_multi_mix_baseline.py
@@ -39,7 +39,7 @@ QUAD_BASELINE_CLI_8 = (
     '--quads_collision_smooth_max_penalty=10.0 '
     '--quads_neighbor_encoder_type=attention '
     '--replay_buffer_sample_prob=0.75 --save_milestones_sec=900 '
-    '--anneal_collision_steps=0 --normalize_input=False --normalize_returns=False --reward_clip=10 '
+    '--anneal_collision_steps=300000000 --normalize_input=False --normalize_returns=False --reward_clip=10 '
     '--decorrelate_experience_max_seconds=10 --force_envs_single_thread=True '
     '--with_wandb=True --wandb_project=Quad-Swarm-RL --wandb_group=test_anneal'
 )

--- a/swarm_rl/runs/quad_multi_mix_baseline.py
+++ b/swarm_rl/runs/quad_multi_mix_baseline.py
@@ -41,7 +41,7 @@ QUAD_BASELINE_CLI_8 = (
     '--replay_buffer_sample_prob=0.75 --save_milestones_sec=900 '
     '--anneal_collision_steps=300000000 --normalize_input=False --normalize_returns=False --reward_clip=10 '
     '--decorrelate_experience_max_seconds=10 --force_envs_single_thread=True '
-    '--with_wandb=True --wandb_project=Quad-Swarm-RL --wandb_group=test_anneal'
+    '--with_wandb=True --wandb_project=Quad-Swarm-RL --wandb_group=swarm-rl'
 )
 
 # For scale, need to change

--- a/swarm_rl/runs/quad_multi_mix_baseline.py
+++ b/swarm_rl/runs/quad_multi_mix_baseline.py
@@ -24,7 +24,7 @@ QUAD_BASELINE_CLI = (
 )
 
 QUAD_BASELINE_CLI_8 = (
-    'python -m swarm_rl.train --env=quadrotor_multi --train_for_env_steps=2000000000 --algo=APPO --use_rnn=False '
+    'python -m swarm_rl.train --env=quadrotor_multi --train_for_env_steps=1000000000 --algo=APPO --use_rnn=False '
     '--num_workers=36 --num_envs_per_worker=4 --learning_rate=0.0001 --ppo_clip_value=5.0 --recurrence=1 '
     '--nonlinearity=tanh --actor_critic_share_weights=False --policy_initialization=xavier_uniform '
     '--adaptive_stddev=False --with_vtrace=False --max_policy_lag=100000000 --rnn_size=256 '
@@ -39,8 +39,9 @@ QUAD_BASELINE_CLI_8 = (
     '--quads_collision_smooth_max_penalty=10.0 '
     '--quads_neighbor_encoder_type=attention '
     '--replay_buffer_sample_prob=0.75 --save_milestones_sec=900 '
-    '--anneal_collision_steps=300000000 '
-    '--with_wandb=True --wandb_project=Quad-Swarm-RL --wandb_group=test_updated_code'
+    '--anneal_collision_steps=0 --normalize_input=False --normalize_returns=False --reward_clip=10 '
+    '--decorrelate_experience_max_seconds=10 --force_envs_single_thread=True '
+    '--with_wandb=True --wandb_project=Quad-Swarm-RL --wandb_group=test_anneal'
 )
 
 # For scale, need to change

--- a/swarm_rl/runs/quad_multi_mix_baseline.py
+++ b/swarm_rl/runs/quad_multi_mix_baseline.py
@@ -39,7 +39,7 @@ QUAD_BASELINE_CLI_8 = (
     '--quads_collision_smooth_max_penalty=10.0 '
     '--quads_neighbor_encoder_type=attention '
     '--replay_buffer_sample_prob=0.75 --save_milestones_sec=900 '
-    '--anneal_collision_steps=300000000'
+    '--anneal_collision_steps=300000000 '
     '--with_wandb=True --wandb_project=Quad-Swarm-RL --wandb_group=test_updated_code'
 )
 

--- a/swarm_rl/runs/quad_multi_mix_baseline.py
+++ b/swarm_rl/runs/quad_multi_mix_baseline.py
@@ -40,6 +40,7 @@ QUAD_BASELINE_CLI_8 = (
     '--quads_neighbor_encoder_type=attention '
     '--replay_buffer_sample_prob=0.75 --save_milestones_sec=900 '
     '--anneal_collision_steps=300000000'
+    '--with_wandb=True --wandb_project=Quad-Swarm-RL --wandb_group=test_updated_code'
 )
 
 # For scale, need to change

--- a/swarm_rl/runs/quad_multi_mix_baseline_attn_8.py
+++ b/swarm_rl/runs/quad_multi_mix_baseline_attn_8.py
@@ -17,7 +17,7 @@ _experiment = Experiment(
 
 run_name = timeStamped("test_anneal", fmt="{fname}_%Y%m%d_%H%M")
 
-RUN_DESCRIPTION = RunDescription('paper_quads_multi_mix_baseline_8a_attn_v116', experiments=[_experiment])
+RUN_DESCRIPTION = RunDescription(run_name, experiments=[_experiment])
 
 # On Brain server, when you use num_workers = 72, if the system reports: Resource temporarily unavailable,
 # then, try to use two commands below

--- a/swarm_rl/runs/quad_multi_mix_baseline_attn_8.py
+++ b/swarm_rl/runs/quad_multi_mix_baseline_attn_8.py
@@ -2,6 +2,8 @@ from sample_factory.launcher.run_description import RunDescription, Experiment, 
 
 from swarm_rl.runs.quad_multi_mix_baseline import QUAD_BASELINE_CLI_8
 
+from swarm_rl.utils import timeStamped
+
 _params = ParamGrid([
     ('quads_neighbor_encoder_type', ['attention']),
     ('seed', [0000, 1111, 2222, 3333]),
@@ -12,6 +14,8 @@ _experiment = Experiment(
     QUAD_BASELINE_CLI_8,
     _params.generate_params(randomize=False),
 )
+
+run_name = timeStamped("test_anneal", fmt="{fname}_%Y%m%d_%H%M")
 
 RUN_DESCRIPTION = RunDescription('paper_quads_multi_mix_baseline_8a_attn_v116', experiments=[_experiment])
 

--- a/swarm_rl/utils.py
+++ b/swarm_rl/utils.py
@@ -1,0 +1,6 @@
+import datetime
+
+
+def timeStamped(fname, fmt='%Y-%m-%d-%H-%M-%S-{fname}'):
+    # This creates a timestamped filename so we don't overwrite our good work
+    return datetime.datetime.now().strftime(fmt).format(fname=fname)

--- a/train_brain.sh
+++ b/train_brain.sh
@@ -1,7 +1,0 @@
-python -m sample_factory.launcher.run \
---run=swarm_rl.runs.quad_multi_mix_baseline_attn_8 \
---backend=slurm --slurm_workdir=slurm_output \
---experiment_suffix=slurm --pause_between=1 \
---slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 \
---slurm_sbatch_template=/home/zhaojing/sbatch.sh \
---slurm_print_only=False

--- a/train_brain.sh
+++ b/train_brain.sh
@@ -1,0 +1,7 @@
+python -m sample_factory.launcher.run \
+--run=swarm_rl.runs.quad_multi_mix_baseline_attn_8 \
+--backend=slurm --slurm_workdir=slurm_output \
+--experiment_suffix=slurm --pause_between=1 \
+--slurm_gpus_per_job=1 --slurm_cpus_per_gpu=16 \
+--slurm_sbatch_template=/home/zhaojing/sbatch.sh \
+--slurm_print_only=False


### PR DESCRIPTION
Disable RewardShapingInterface in RewardShaping wrapper to fix annealing bug in sf 2.0.
Other minor changes include adding a timestamp for each experiment so we don't need to rename exp name every time.